### PR TITLE
Fix action callback receiving incorrect `args`

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -15,7 +15,7 @@ import {
 } from "./types";
 import { handleEmoji, report as _report } from "./utility";
 import { v4 } from "uuid";
-import { RoutedAction } from "./routedAction";
+import { errorTrigger, RoutedAction } from "./routedAction";
 import { Router } from "./router";
 
 /**
@@ -76,7 +76,7 @@ export const ActionFactory = (bot: Bot) =>
         if (pointer.errorAction) {
           yield (prevAction = new Action(
             { ...this.params, ...newParams },
-            new RoutedAction(this.router, pointer.errorAction),
+            new RoutedAction(this.router, pointer.errorAction, errorTrigger),
             prevAction.id
           ));
         }

--- a/src/routedAction.ts
+++ b/src/routedAction.ts
@@ -1,13 +1,23 @@
 import { Router } from "./router";
 import { ActionObject } from "./types";
 
+export const errorTrigger = Symbol("error symbol");
+
+export const typoTrigger = Symbol("typo symbol");
+
+type TriggerType = string | Symbol;
+
 export class RoutedAction implements ActionObject {
   description?: string | undefined;
   onError?: ActionObject["onError"];
   parameters?: ActionObject["parameters"];
   response?: ActionObject["response"];
   reaction?: ActionObject["reaction"];
-  constructor(public router: Router, public rawAction: ActionObject) {
+  constructor(
+    public router: Router,
+    public rawAction: ActionObject,
+    public trigger: TriggerType
+  ) {
     this.description = rawAction.description;
     this.onError = rawAction.onError;
     this.parameters = rawAction.parameters;
@@ -17,6 +27,8 @@ export class RoutedAction implements ActionObject {
   }
 
   routeError() {
-    return this.onError && new RoutedAction(this.router, this.onError);
+    return (
+      this.onError && new RoutedAction(this.router, this.onError, errorTrigger)
+    );
   }
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,7 +6,7 @@ import {
 import autobind from "autobind-decorator";
 import { Bot } from ".";
 import { CommandsHandler } from "./handler";
-import { RoutedAction } from "./routedAction";
+import { RoutedAction, typoTrigger } from "./routedAction";
 import { SlashCommands } from "./slashCommands";
 import {
   BotAction,
@@ -170,14 +170,18 @@ export class Router {
         const [typoAction, options] = typoArray;
         const matches = this.handler.findSimilar(trigger, options);
         if (matches.length) {
-          return new RoutedAction(this, {
-            response: (params) => typoAction(params, matches),
-          });
+          return new RoutedAction(
+            this,
+            {
+              response: (params) => typoAction(params, matches),
+            },
+            typoTrigger
+          );
         }
       }
     }
 
-    return searchResult && new RoutedAction(this, searchResult);
+    return searchResult && new RoutedAction(this, searchResult, trigger);
   }
 
   /**


### PR DESCRIPTION
Router(cards) -> router(search) -> two words 

Expected args -> two words
Actual args -> h two words
routedTrigger was not adding the last trigger (search) correctly. Actual `cards cards`

Fixed by adding a new parameter to RoutedAction, along with a couple new Symbols and logic to handle error actions and typos