### PR TITLE
Timeout prevention

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,16 +165,16 @@ bot.onTypo(
 Should be noted that onTypo is available router-wise and will always attempt to fetch a callback from any parent router (incluiding the Bot object's)
 
 `onTypo` can take a second argument in the form of an object
+
 ```ts
 {
-  maxDistance: number 
-  maxSuggestions: number
+  maxDistance: number;
+  maxSuggestions: number;
 }
 ```
 
 `maxDistance`: Maximum [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) allowed
 `maxSuggestions`: Max amount of suggestions to be provided to the callback
-
 
 ### Routing
 
@@ -256,6 +256,17 @@ bot.on("debug_register", async ({ guild }) =>
 Be sure to call this method _AFTER_ all of your commands and routers have been registered. For troubleshooting, `Bot#compileCommands` will return the objects that will then be passed to the Discord API (via `Bot#commands.overwriteCommands`)
 
 DJS-diy will automatically create subcommands in the case of routers. Be mindful of the [nesting limitations](https://discord.com/developers/docs/interactions/application-commands#subcommands-and-subcommand-groups).
+
+### Slash command timeout prevention
+
+Routers (and the Bot object) support having a loading action be executed for any slash command interactions that may take longer than 2.5s to execute [(Discord's official timeout is 3s)](https://discord.com/developers/docs/interactions/receiving-and-responding#responding-to-an-interaction).
+
+This action is a sendable message, meaning it can be a string or a function which receives ActionParameters. Do note that for performance reasons, this action can't be `async`
+
+```ts
+bot.onLoading(({ author }) => `I'm working on it, ${author.username}!`);
+router1.onLoading("Hold tight!!!");
+```
 
 ### Async Jobs
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ts-jest": "^26.5.4",
     "ts-node": "^9.1.1",
     "typedoc": "^0.22.15",
-    "typescript": "^4.5.2"
+    "typescript": "^4.7.4"
   },
   "files": [
     "dist",

--- a/src/IAction.ts
+++ b/src/IAction.ts
@@ -1,0 +1,41 @@
+import { Message } from "discord.js";
+import { APIMessage } from "discord.js/node_modules/discord-api-types";
+import { Bot } from "./bot";
+import { RoutedAction } from "./routedAction";
+import { Router } from "./router";
+import {
+  ActionObject,
+  ActionParameters,
+  ReactionAction,
+  ResponseAction,
+} from "./types";
+
+/**
+ * Represents a singular action to be executed
+ */
+export abstract class IAction {
+  bot: Bot;
+  id: string;
+  router: Router;
+  constructor(
+    public params: ActionParameters,
+    public action: RoutedAction,
+    _invokerId: string | undefined
+  ) {}
+
+  abstract report(..._stuff: string[]): void;
+
+  abstract hasError(): boolean;
+
+  abstract getError(
+    newParams: Partial<ActionParameters>
+  ): Generator<IAction | undefined>;
+
+  abstract execResponse(
+    response?: ResponseAction
+  ): Promise<Message | APIMessage | undefined>;
+
+  abstract execReaction(reaction?: ReactionAction): Promise<void>;
+
+  abstract executeAll(action?: ActionObject): Promise<void>;
+}

--- a/src/action.ts
+++ b/src/action.ts
@@ -16,15 +16,19 @@ import {
 import { handleEmoji, report as _report } from "./utility";
 import { v4 } from "uuid";
 import { errorTrigger, RoutedAction } from "./routedAction";
-import { Router } from "./router";
+import type { Router } from "./router";
+import { INTERACTION_PROCESS_MS } from "./constants";
+import { IAction } from "./IAction";
 
 /**
  * Creates a new class containing the passed `Bot` value inside of it
  * @param bot `Bot` object
  * @returns `Action` class
  */
-export const ActionFactory = (bot: Bot) =>
-  class Action {
+export const ActionFactory = (
+  bot: Bot
+): new (...k: ConstructorParameters<typeof IAction>) => IAction =>
+  class Action implements IAction {
     bot: Bot = bot;
     id: string;
     router: Router;

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,17 +1,13 @@
-import {
-  CommandInteraction,
-  EmojiResolvable,
-  Interaction,
-  Message,
-} from "discord.js";
-import { Bot } from "./bot";
+import { EmojiResolvable, Interaction, Message } from "discord.js";
+import type { Bot } from "./bot";
 import { ActionError } from "./error";
-import { SendableMessage } from "./types";
-import {
+import type {
   ActionObject,
   ActionParameters,
   ReactionAction,
   ResponseAction,
+  SendableMessage,
+  SlashCommandLoadingAction,
 } from "./types";
 import { handleEmoji, report as _report } from "./utility";
 import { v4 } from "uuid";
@@ -71,7 +67,7 @@ export const ActionFactory = (
       if (this.hasError()) {
         const routedError = this.action.routeError();
         yield (prevAction = new Action(
-          { ...this.params, ...newParams },
+          <ActionParameters>{ ...this.params, ...newParams },
           routedError!,
           prevAction.id
         ));
@@ -79,7 +75,7 @@ export const ActionFactory = (
       while (pointer) {
         if (pointer.errorAction) {
           yield (prevAction = new Action(
-            { ...this.params, ...newParams },
+            <ActionParameters>{ ...this.params, ...newParams },
             new RoutedAction(this.router, pointer.errorAction, errorTrigger),
             prevAction.id
           ));
@@ -90,9 +86,29 @@ export const ActionFactory = (
     }
 
     async execResponse(_response?: ResponseAction) {
+      const { msg, type } = this.params;
+
+      if (type === "command") {
+        //initiate timeout prevention
+        bot.interactionTimeouts[msg.id] = setTimeout(async () => {
+          if (!msg.deferred) {
+            //inform user
+            await msg.deferReply();
+          }
+          if (!msg.replied) {
+            //if there's a loading action, display it
+            const loadingAction = this.router.findLoading();
+            if (loadingAction) {
+              await this.handleActionReply(loadingAction);
+            }
+          }
+          //timeout prevented, remove from record
+          this.removeInteractionTimeout();
+        }, INTERACTION_PROCESS_MS);
+      }
+
       const response = _response ?? this.action.response;
       if (!response) return;
-      const { msg } = this.params;
       if (!msg.channel) {
         throw new ActionError(
           "response",
@@ -100,19 +116,41 @@ export const ActionFactory = (
         );
       }
 
+      //handle real action
+      const result = await this.handleActionReply(response);
+      //timeout no longer needed
+      this.removeInteractionTimeout();
+      return result;
+    }
+
+    private removeInteractionTimeout() {
+      const {
+        msg: { id },
+      } = this.params;
+      if (bot.interactionTimeouts[id]) {
+        clearTimeout(bot.interactionTimeouts[id]);
+        delete bot.interactionTimeouts[id];
+      }
+    }
+
+    private async handleActionReply(
+      responseAction: SlashCommandLoadingAction | ResponseAction
+    ) {
+      const { msg, type } = this.params;
       try {
         let reply: SendableMessage | undefined;
-        if (typeof response === "string") reply = response;
-        else if (typeof response === "function")
-          reply = await response(this.params);
-        if (msg instanceof CommandInteraction) {
-          if (msg.replied) {
-            return !!reply && msg.editReply(await reply);
+        if (typeof responseAction === "string") reply = responseAction;
+        else if (typeof responseAction === "function")
+          reply = await responseAction(this.params);
+        if (type === "command") {
+          if (msg.replied || msg.deferred) {
+            //if message has been deferred, just update content
+            return reply ? msg.editReply(await reply) : undefined;
           }
           reply && (await msg.reply(await reply));
           return msg.fetchReply();
         }
-        return !!reply && (await msg.channel.send(await reply));
+        return reply ? await msg.channel.send(await reply) : undefined;
       } catch (e) {
         throw new ActionError("response", e.message, e);
       }
@@ -176,7 +214,14 @@ export const ActionFactory = (
       let responseMessage: Message | undefined = undefined;
       try {
         const output = await Promise.all(promiseArray);
-        responseMessage = output[0] || undefined;
+        const outputMessage: Message | { id: string } | undefined =
+          output[0] || undefined;
+        if (outputMessage && !(outputMessage instanceof Message)) {
+          //if it's not a full message, refetch it
+          responseMessage = await msg.channel?.messages.fetch(outputMessage.id);
+        } else {
+          responseMessage = outputMessage || undefined;
+        }
       } catch (e) {
         this.report("Exception raised =>", e);
         if (e instanceof ActionError) {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -300,7 +300,9 @@ export class Bot extends BotBase {
 
     const action = this.router.findAction(commandName);
 
-    if (!action) return;
+    if (!action) {
+      return;
+    }
 
     const params: ActionParameters["parameters"] = {};
 
@@ -330,7 +332,11 @@ export class Bot extends BotBase {
           }
         }
       } else {
-        params["arguments"] = interaction.options.getString("arguments", true);
+        params["arguments"] =
+          interaction.options.getString(
+            "arguments",
+            false /** not required */
+          ) ?? undefined;
       }
 
       const actionParameters = await this.createParams(
@@ -341,7 +347,9 @@ export class Bot extends BotBase {
       );
 
       return await this.handleAction(actionParameters, action);
-    } catch (e) {}
+    } catch (e) {
+      this.report(`OOPS!!! => ${e}`, e);
+    }
   }
 
   private async messageHandler(msg: Message) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,7 @@
+/** Max milliseconds we can wait before replying *anything* to a Discord interaction
+ * to prevent timeout.
+ * `If the 3 second deadline is exceeded, the token will be invalidated.`
+ * 2.5 seconds to play it safe
+ */
+export const INTERACTION_PROCESS_MS = 2.5 * 1000;
+export const DEFAULT_TIMEOUT_PREVENTION_RESPONSE = "Loading...";

--- a/src/router.ts
+++ b/src/router.ts
@@ -15,6 +15,7 @@ import {
   CommandCollection,
   TypoAction,
   TypoOptions,
+  SlashCommandLoadingAction,
 } from "./types";
 import { firstWord, printNested, report as _report } from "./utility";
 
@@ -31,6 +32,7 @@ export class Router {
   readonly errorAction: ActionObject;
   typoAction: TypoAction | undefined = undefined;
   typoOptions: TypoOptions | undefined = undefined;
+  loadingAction: SlashCommandLoadingAction | undefined = undefined;
 
   constructor() {
     this.options = {
@@ -142,6 +144,14 @@ export class Router {
   }
 
   @autobind
+  findLoading(): SlashCommandLoadingAction | undefined {
+    if (!this.loadingAction) {
+      return this.parent?.findLoading();
+    }
+    return this.loadingAction;
+  }
+
+  @autobind
   fullTrigger(): string[] {
     return [...(this.parent?.fullTrigger() ?? []), this.trigger].filter(
       (x): x is string => typeof x === "string"
@@ -248,6 +258,12 @@ export class Router {
     if (options) {
       this.typoOptions = options;
     }
+    return this;
+  }
+
+  @autobind
+  onLoading(action: SlashCommandLoadingAction) {
+    this.loadingAction = action;
     return this;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,10 +7,10 @@ import { APIRole } from "discord-api-types/v9";
 import {
   ApplicationCommandOptionType,
   ButtonInteraction,
+  CommandInteraction,
   EmojiResolvable,
   Guild,
   GuildMember,
-  Interaction,
   Message,
   MessageActionRow,
   MessageButtonOptions,
@@ -33,10 +33,36 @@ type NonNullableObject<T> = {
   [K in keyof T]: Exclude<T[K], null>;
 };
 
-/**Object passed to the action functions on every trigger */
-export interface ActionParameters<
+export type ActionParameters<MW = undefined> = MWActionParameters<MW> &
+  (TextActionParameters | CommandActionParameters);
+
+type ActionTypes = "text" | "command";
+
+export interface MWActionParameters<
   MW extends GenericObject | undefined = undefined
-> {
+> extends BaseActionParameters {
+  middleware?: MW;
+  msg: Message | CommandInteraction;
+  type: ActionTypes;
+}
+
+interface TextActionParameters {
+  /**
+   * Identifies the type of this action, if it's invoked by slash command ("command") or legacy text command ("text")
+   */
+  type: "text";
+  msg: Message;
+}
+interface CommandActionParameters {
+  /**
+   * Identifies the type of this action, if it's invoked by slash command ("command") or legacy text command ("text")
+   */
+  type: "command";
+  msg: CommandInteraction;
+}
+
+/**Object passed to the action functions on every trigger */
+interface BaseActionParameters {
   /**Arguments from the command executed, undefined for slash commands unless no parameter definition was provided */
   args?: string;
 
@@ -55,9 +81,6 @@ export interface ActionParameters<
    * Contains the full error obtained from the catch
    */
   error?: any;
-
-  /**Message that triggered this action */
-  msg: Message | Interaction;
   /**The user who triggered the action */
   author: User;
   /**The channel this command will be sent in */
@@ -113,10 +136,8 @@ export interface ActionParameters<
 
   /**Internal, used for `asyncEffect` */
   __asyncJobs: {
-    doAfter: Parameters<ActionParameters["asyncEffect"]>[0];
+    doAfter: Parameters<BaseActionParameters["asyncEffect"]>[0];
   }[];
-
-  middleware?: MW;
 }
 
 export type ParametersMiddleWare<

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,6 +195,14 @@ export type TypoAction = (
   similar: string[]
 ) => SendableMessage;
 
+/**
+ * Called when a slash command takes longer than the set timeout to process.
+ * Its result is then edited to the real expected message.
+ */
+export type SlashCommandLoadingAction =
+  | ((params: ActionParameters) => Awaited<SendableMessage>)
+  | Awaited<SendableMessage>;
+
 export interface TypoOptions {
   maxDistance?: number;
   maxSuggestions?: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4745,10 +4745,10 @@ typedoc@^0.22.15:
     minimatch "^5.0.1"
     shiki "^0.10.1"
 
-typescript@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
-  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 undefsafe@^2.0.3:
   version "2.0.3"


### PR DESCRIPTION
Create new `Bot#onLoading` and `Router#onLoading` API to set a callback for timeout prevention for slash commands that may take longer than 2.5s to execute 