### PR TITLE
Aid/improve handling of `Unknown Interaction` discord.js errors

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -243,10 +243,10 @@ export const ActionFactory = (
           >;
           if (invoker.replied || invoker.deferred) {
             //if message has been deferred, just update content
-            return reply ? invoker.editReply(await reply) : undefined;
+            return reply ? await invoker.editReply(await reply) : undefined;
           }
           reply && (await invoker.reply(await reply));
-          return invoker.fetchReply();
+          return await invoker.fetchReply();
         }
 
         return reply

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -19,6 +19,7 @@ import { errorTrigger, RoutedAction, typoTrigger } from "./routedAction";
 import { ApplicationCommands } from "./applicationCommands";
 import { InteractionHandler } from "./interactionHandler";
 import { IAction } from "./IAction";
+import { ActionError } from "./error";
 
 interface BotOptions {
   prefix?: string;
@@ -383,7 +384,10 @@ export class Bot extends BotBase {
     try {
       await action.executeAll();
     } catch (e) {
-      for (const errorAction of action.getError({ args: e.message })) {
+      for (const errorAction of action.getError({
+        args: e.message,
+        error: e instanceof ActionError ? e.e : e,
+      })) {
         if (!errorAction) break;
         try {
           await errorAction.executeAll();

--- a/src/interactionHandler.ts
+++ b/src/interactionHandler.ts
@@ -100,6 +100,13 @@ export class InteractionHandler {
 
   @autobind
   private async handleSlashCommandInteraction(interaction: CommandInteraction) {
+    interaction
+      .deferReply()
+      .catch((e) =>
+        this.report(
+          `An error ocurred while deferring interaction ${interaction.id}: ${e?.message}`
+        )
+      );
     const action = this.bot.router.findAction(
       this.constructFullTrigger(interaction)
     );


### PR DESCRIPTION
- Defer slash command interactions ASAP
- Await all interaction replies so they get caught by action handler
- Pass full error to onError handler